### PR TITLE
Revert "changed format string to allow for 4 letter labels"

### DIFF
--- a/proper-PDBwrite.chmfile
+++ b/proper-PDBwrite.chmfile
@@ -62,7 +62,7 @@ close $c
 set out [open "result.pdb" w ]
 foreach a $atomindexlist b $segmentlist c $residlist d $resnamelist e $atomnamelist f $typeslist cx $coords_x cy $coords_y cz $coords_z el $ellist {
  #ATOM      1  N   SER A   2      65.342  32.035  32.324  1.00  0.00           N
-             set fmt1 "ATOM%7d %4s %4s %-1s %5d %8.3f%8.3f%8.3f %6s %6s %10s %2s"
+             set fmt1 "ATOM%7d %4s%4s%-1s%5d%12.3f%8.3f%8.3f%6s%6s%10s%2s"
  puts $out [format $fmt1 $a $e $d " " $c $cx $cy $cz "1.00" "0.00" $b $el]
 
 }


### PR DESCRIPTION
This reverts commit 0a267b5482a0be42941021567c7d2c56cd54d1c3.

The PDB file format actually is supposed to be that way (without spaces in between columns)